### PR TITLE
use read_serializer in get_success_headers call

### DIFF
--- a/drf_rw_serializers/mixins.py
+++ b/drf_rw_serializers/mixins.py
@@ -34,7 +34,7 @@ class CreateModelMixin(mixins.CreateModelMixin):
         self.perform_create(write_serializer)
 
         read_serializer = self.get_read_serializer(write_serializer.instance)
-        headers = self.get_success_headers(write_serializer.data)
+        headers = self.get_success_headers(read_serializer.data)
 
         return Response(read_serializer.data, status=status.HTTP_201_CREATED, headers=headers)
 


### PR DESCRIPTION
**Description:** This avoids an error during the computation of write_serializer.data when the object to be serialized contains a field which is a GenericRelation.

The error states that *'url' is not a field of the GenericRelation*, which may be true because the field it's only in my read_serializer and not in the write_serializer (I am not needing it).

**Author concerns:** It's a quick and dirty fix, but what's the difference between the two serializers for this particular part of DRF? 