### PR TITLE
Ignores too-many-function-args rule on pylint

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -34,6 +34,7 @@ pylint:
     - no-self-use
     - no-member
     - useless-object-inheritance
+    - too-many-function-args
   options:
     max-line-length: 100
     max-parents: 20


### PR DESCRIPTION
**Description:** Ignores pylint rule that was breaking the build  