### PR TITLE
upgrade deps to fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,28 +3,20 @@
 language: python
 
 python:
-  - 2.7
-  - 3.6
+  - 3.7
 
 env:
-  - TOXENV=django110
   - TOXENV=django111
   - TOXENV=django20
   - TOXENV=django21
   - TOXENV=django22
+  - TOXENV=django30
 
 matrix:
-  exclude:
-    - python: 2.7
-      env: TOXENV=django20
-    - python: 2.7
-      env: TOXENV=django21
-    - python: 2.7
-      env: TOXENV=django22
   include:
-    - python: 3.6
+    - python: 3.7
       env: TOXENV=quality
-    - python: 3.6
+    - python: 3.7
       env: TOXENV=docs
 
 cache:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
-*
+* Support Python 3.7
+* Support Django 3.0
+* Drop support to Django 1.10
+* Drop support to Python 2.7
+* Drop support to Python 3.6
 
 [1.0.2] - 2019-08-30
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Vinta Serviços e Soluções Tecnológicas Ltda
+Copyright (c) 2020 Vinta Serviços e Soluções Tecnológicas Ltda
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ This project, as other Vinta open-source projects, is used in products of Vinta
 clients. We are always looking for exciting work, so if you need any commercial
 support, feel free to get in touch: contact@vinta.com.br
 
-Copyright (c) 2018 Vinta Serviços e Soluções Tecnológicas Ltda
+Copyright (c) 2020 Vinta Serviços e Soluções Tecnológicas Ltda
 
 
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,4 +1,3 @@
 # Core requirements for using this application
 
-djangorestframework==3.9.4   # pinned to support python 2.7
-more-itertools==5.0.0        # pinned to support python 2.7
+djangorestframework

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -15,7 +15,7 @@ click==7.0                # via pip-tools, safety
 cryptography==2.8         # via secretstorage
 diff-cover==2.5.2
 django==3.0.2
-djangorestframework==3.9.4
+djangorestframework==3.11.0
 docutils==0.16            # via readme-renderer
 dodgy==0.2.1              # via prospector
 dparse==0.4.1             # via safety
@@ -33,7 +33,6 @@ keyring==21.1.0           # via twine
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via prospector, pylint
-more-itertools==5.0.0
 packaging==20.1           # via dparse, safety, tox
 pbr==5.4.4                # via stevedore
 pep8-naming==0.4.1        # via prospector
@@ -62,7 +61,7 @@ requirements-detector==0.6  # via prospector
 safety==1.8.5
 secretstorage==3.1.2      # via keyring
 setoptconf==0.2.0         # via prospector
-six==1.14.0               # via astroid, bandit, bleach, cryptography, diff-cover, dparse, more-itertools, packaging, pip-tools, readme-renderer, stevedore, tox
+six==1.14.0               # via astroid, bandit, bleach, cryptography, diff-cover, dparse, packaging, pip-tools, readme-renderer, stevedore, tox
 smmap2==2.0.5             # via gitdb2
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.0           # via django

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,75 +4,81 @@
 #
 #    pip-compile --output-file=requirements/dev.txt requirements/base.in requirements/dev.in requirements/quality.in
 #
-astroid==2.2.5
-attrs==19.1.0             # via packaging
+asgiref==3.2.3            # via django
+astroid==2.3.3
 bandit==1.6.2
 bleach==3.1.0             # via readme-renderer
-certifi==2019.6.16        # via requests
+certifi==2019.11.28       # via requests
+cffi==1.13.2              # via cryptography
 chardet==3.0.4            # via requests
 click==7.0                # via pip-tools, safety
-diff-cover==2.3.0
-django==2.2.4
+cryptography==2.8         # via secretstorage
+diff-cover==2.5.2
+django==3.0.2
 djangorestframework==3.9.4
-docutils==0.15.2          # via readme-renderer
-dodgy==0.1.9              # via prospector
+docutils==0.16            # via readme-renderer
+dodgy==0.2.1              # via prospector
 dparse==0.4.1             # via safety
 filelock==3.0.12          # via tox
-gitdb2==2.0.5             # via gitpython
-gitpython==3.0.2          # via bandit
+gitdb2==2.0.6             # via gitpython
+gitpython==3.0.5          # via bandit
 idna==2.8                 # via requests
-importlib-metadata==0.19  # via pluggy, tox
-inflect==2.1.0            # via jinja2-pluralize
+importlib-metadata==1.5.0  # via inflect, keyring, pluggy, tox, twine
+inflect==4.0.0            # via jinja2-pluralize
 isort==4.3.21
+jeepney==0.4.2            # via keyring, secretstorage
 jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.10.1            # via diff-cover, jinja2-pluralize
-lazy-object-proxy==1.4.2  # via astroid
+jinja2==2.11.0            # via diff-cover, jinja2-pluralize
+keyring==21.1.0           # via twine
+lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via prospector, pylint
 more-itertools==5.0.0
-packaging==19.1           # via dparse, safety, tox
-pbr==5.4.2                # via stevedore
+packaging==20.1           # via dparse, safety, tox
+pbr==5.4.4                # via stevedore
 pep8-naming==0.4.1        # via prospector
-pip-tools==4.1.0
+pip-tools==4.4.0
 pkginfo==1.5.0.1          # via twine
-pluggy==0.12.0            # via tox
-prospector==1.1.7
-py==1.8.0                 # via tox
+pluggy==0.13.1            # via diff-cover, tox
+prospector==1.2.0
+py==1.8.1                 # via tox
 pycodestyle==2.4.0        # via prospector
-pydocstyle==4.0.1         # via prospector
-pyflakes==1.6.0           # via prospector
-pygments==2.4.2           # via diff-cover, readme-renderer
+pycparser==2.19           # via cffi
+pydocstyle==5.0.2         # via prospector
+pyflakes==2.1.1           # via prospector
+pygments==2.5.2           # via diff-cover, readme-renderer
 pylint-flask==0.6         # via prospector
-pylint-plugin-utils==0.5  # via prospector, pylint-celery, pylint-django, pylint-flask
-pylint==2.3.1
+pylint-plugin-utils==0.6  # via prospector, pylint-celery, pylint-django, pylint-flask
+pylint==2.4.4
 pylint_celery==0.3
-pylint_django==2.0.10
-pyparsing==2.4.2          # via packaging
-pytz==2019.2              # via django
-pyyaml==5.1.2             # via bandit, dparse, prospector
+pylint_django==2.0.12
+pyparsing==2.4.6          # via packaging
+pytz==2019.3              # via django
+pyyaml==5.3               # via bandit, dparse, prospector
 readme-renderer==24.0     # via twine
 requests-toolbelt==0.9.1  # via twine
 requests==2.22.0          # via requests-toolbelt, safety, twine
 requirements-detector==0.6  # via prospector
 safety==1.8.5
+secretstorage==3.1.2      # via keyring
 setoptconf==0.2.0         # via prospector
-six==1.12.0               # via astroid, bandit, bleach, diff-cover, dparse, more-itertools, packaging, pip-tools, readme-renderer, stevedore, tox
+six==1.14.0               # via astroid, bandit, bleach, cryptography, diff-cover, dparse, more-itertools, packaging, pip-tools, readme-renderer, stevedore, tox
 smmap2==2.0.5             # via gitdb2
-snowballstemmer==1.9.0    # via pydocstyle
+snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.0           # via django
-stevedore==1.30.1         # via bandit
+stevedore==1.31.0         # via bandit
 toml==0.10.0              # via tox
-tox-battery==0.5.1
-tox==3.13.2
-tqdm==4.35.0              # via twine
-twine==1.13.0
-typed-ast==1.4.0          # via astroid
-urllib3==1.25.3           # via requests
-virtualenv==16.7.4        # via tox
+tox-battery==0.5.2
+tox==3.14.3
+tqdm==4.42.0              # via twine
+twine==3.1.1
+typed-ast==1.4.1          # via astroid
+urllib3==1.25.8           # via requests
+virtualenv==16.7.9        # via tox
 webencodings==0.5.1       # via bleach
-wheel==0.33.6
+wheel==0.34.1
 wrapt==1.11.2             # via astroid
-zipp==0.6.0               # via importlib-metadata
+zipp==2.1.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.2.0        # via safety, twine
+# setuptools

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -5,27 +5,28 @@
 #    pip-compile --output-file=requirements/doc.txt requirements/base.in requirements/doc.in
 #
 alabaster==0.7.12         # via sphinx
+asgiref==3.2.3            # via django
 babel==2.8.0              # via sphinx
 bleach==3.1.0             # via readme-renderer
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via doc8, requests
-djangorestframework==3.9.4
+django==3.0.2             # via djangorestframework
+djangorestframework==3.11.0
 doc8==0.8.0
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 idna==2.8                 # via requests
 imagesize==1.2.0          # via sphinx
 jinja2==2.11.0            # via sphinx
 markupsafe==1.1.1         # via jinja2
-more-itertools==5.0.0
 packaging==20.1           # via sphinx
 pbr==5.4.4                # via stevedore
 pygments==2.5.2           # via readme-renderer, sphinx
 pyparsing==2.4.6          # via packaging
-pytz==2019.3              # via babel
+pytz==2019.3              # via babel, django
 readme-renderer==24.0
 requests==2.22.0          # via sphinx
 restructuredtext-lint==1.3.0  # via doc8
-six==1.14.0               # via bleach, doc8, more-itertools, packaging, readme-renderer, stevedore
+six==1.14.0               # via bleach, doc8, packaging, readme-renderer, stevedore
 snowballstemmer==2.0.0    # via sphinx
 sphinx==2.3.1
 sphinxcontrib-applehelp==1.0.1  # via sphinx
@@ -34,6 +35,7 @@ sphinxcontrib-htmlhelp==1.0.2  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.2  # via sphinx
 sphinxcontrib-serializinghtml==1.1.3  # via sphinx
+sqlparse==0.3.0           # via django
 stevedore==1.31.0         # via doc8
 urllib3==1.25.8           # via requests
 webencodings==0.5.1       # via bleach

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -5,39 +5,38 @@
 #    pip-compile --output-file=requirements/doc.txt requirements/base.in requirements/doc.in
 #
 alabaster==0.7.12         # via sphinx
-attrs==19.1.0             # via packaging
-babel==2.7.0              # via sphinx
+babel==2.8.0              # via sphinx
 bleach==3.1.0             # via readme-renderer
-certifi==2019.6.16        # via requests
+certifi==2019.11.28       # via requests
 chardet==3.0.4            # via doc8, requests
 djangorestframework==3.9.4
 doc8==0.8.0
-docutils==0.15.2          # via doc8, readme-renderer, restructuredtext-lint, sphinx
+docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 idna==2.8                 # via requests
-imagesize==1.1.0          # via sphinx
-jinja2==2.10.1            # via sphinx
+imagesize==1.2.0          # via sphinx
+jinja2==2.11.0            # via sphinx
 markupsafe==1.1.1         # via jinja2
 more-itertools==5.0.0
-packaging==19.1           # via sphinx
-pbr==5.4.2                # via stevedore
-pygments==2.4.2           # via readme-renderer, sphinx
-pyparsing==2.4.2          # via packaging
-pytz==2019.2              # via babel
+packaging==20.1           # via sphinx
+pbr==5.4.4                # via stevedore
+pygments==2.5.2           # via readme-renderer, sphinx
+pyparsing==2.4.6          # via packaging
+pytz==2019.3              # via babel
 readme-renderer==24.0
 requests==2.22.0          # via sphinx
 restructuredtext-lint==1.3.0  # via doc8
-six==1.12.0               # via bleach, doc8, more-itertools, packaging, readme-renderer, stevedore
-snowballstemmer==1.9.0    # via sphinx
-sphinx==2.2.0
+six==1.14.0               # via bleach, doc8, more-itertools, packaging, readme-renderer, stevedore
+snowballstemmer==2.0.0    # via sphinx
+sphinx==2.3.1
 sphinxcontrib-applehelp==1.0.1  # via sphinx
 sphinxcontrib-devhelp==1.0.1  # via sphinx
 sphinxcontrib-htmlhelp==1.0.2  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.2  # via sphinx
 sphinxcontrib-serializinghtml==1.1.3  # via sphinx
-stevedore==1.30.1         # via doc8
-urllib3==1.25.3           # via requests
+stevedore==1.31.0         # via doc8
+urllib3==1.25.8           # via requests
 webencodings==0.5.1       # via bleach
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.2.0        # via sphinx
+# setuptools

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,45 +4,44 @@
 #
 #    pip-compile --output-file=requirements/quality.txt requirements/quality.in
 #
-astroid==2.2.5
-attrs==19.1.0             # via packaging
+astroid==2.3.3
 bandit==1.6.2
-certifi==2019.6.16        # via requests
+certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
 click==7.0                # via safety
-dodgy==0.1.9              # via prospector
+dodgy==0.2.1              # via prospector
 dparse==0.4.1             # via safety
-gitdb2==2.0.5             # via gitpython
-gitpython==3.0.2          # via bandit
+gitdb2==2.0.6             # via gitpython
+gitpython==3.0.5          # via bandit
 idna==2.8                 # via requests
 isort==4.3.21
-lazy-object-proxy==1.4.2  # via astroid
+lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via prospector, pylint
-packaging==19.1           # via dparse, safety
-pbr==5.4.2                # via stevedore
+packaging==20.1           # via dparse, safety
+pbr==5.4.4                # via stevedore
 pep8-naming==0.4.1        # via prospector
-prospector==1.1.7
+prospector==1.2.0
 pycodestyle==2.4.0        # via prospector
-pydocstyle==4.0.1         # via prospector
-pyflakes==1.6.0           # via prospector
+pydocstyle==5.0.2         # via prospector
+pyflakes==2.1.1           # via prospector
 pylint-flask==0.6         # via prospector
-pylint-plugin-utils==0.5  # via prospector, pylint-celery, pylint-django, pylint-flask
-pylint==2.3.1
+pylint-plugin-utils==0.6  # via prospector, pylint-celery, pylint-django, pylint-flask
+pylint==2.4.4
 pylint_celery==0.3
-pylint_django==2.0.10
-pyparsing==2.4.2          # via packaging
-pyyaml==5.1.2             # via bandit, dparse, prospector
+pylint_django==2.0.12
+pyparsing==2.4.6          # via packaging
+pyyaml==5.3               # via bandit, dparse, prospector
 requests==2.22.0          # via safety
 requirements-detector==0.6  # via prospector
 safety==1.8.5
 setoptconf==0.2.0         # via prospector
-six==1.12.0               # via astroid, bandit, dparse, packaging, stevedore
+six==1.14.0               # via astroid, bandit, dparse, packaging, stevedore
 smmap2==2.0.5             # via gitdb2
-snowballstemmer==1.9.0    # via pydocstyle
-stevedore==1.30.1         # via bandit
-typed-ast==1.4.0          # via astroid
-urllib3==1.25.3           # via requests
+snowballstemmer==2.0.0    # via pydocstyle
+stevedore==1.31.0         # via bandit
+typed-ast==1.4.1          # via astroid
+urllib3==1.25.8           # via requests
 wrapt==1.11.2             # via astroid
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.2.0        # via safety
+# setuptools

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -4,4 +4,4 @@
 pytest-cov                # pytest extension for code coverage statistics
 pytest-django             # pytest extension for better Django support
 model-mommy               # helper to create random data for tests 
-pytest==4.6.5             # pinned to support python 2.7
+pytest

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,22 +5,21 @@
 #    pip-compile --output-file=requirements/test.txt requirements/base.in requirements/test.in
 #
 asgiref==3.2.3            # via django
-atomicwrites==1.3.0       # via pytest
 attrs==19.3.0             # via pytest
 coverage==5.0.3           # via pytest-cov
-djangorestframework==3.9.4
+djangorestframework==3.11.0
 importlib-metadata==1.5.0  # via pluggy, pytest
 model-mommy==2.0.0
-more-itertools==5.0.0
+more-itertools==8.2.0     # via pytest
 packaging==20.1           # via pytest
 pluggy==0.13.1            # via pytest
 py==1.8.1                 # via pytest
 pyparsing==2.4.6          # via packaging
 pytest-cov==2.8.1
 pytest-django==3.8.0
-pytest==4.6.5
+pytest==5.3.5
 pytz==2019.3              # via django
-six==1.14.0               # via more-itertools, packaging, pytest
+six==1.14.0               # via packaging
 sqlparse==0.3.0           # via django
 wcwidth==0.1.8            # via pytest
 zipp==2.1.0               # via importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,22 +4,23 @@
 #
 #    pip-compile --output-file=requirements/test.txt requirements/base.in requirements/test.in
 #
+asgiref==3.2.3            # via django
 atomicwrites==1.3.0       # via pytest
-attrs==19.1.0             # via packaging, pytest
-coverage==4.5.4           # via pytest-cov
+attrs==19.3.0             # via pytest
+coverage==5.0.3           # via pytest-cov
 djangorestframework==3.9.4
-importlib-metadata==0.19  # via pluggy, pytest
-model-mommy==1.6.0
+importlib-metadata==1.5.0  # via pluggy, pytest
+model-mommy==2.0.0
 more-itertools==5.0.0
-packaging==19.1           # via pytest
-pluggy==0.12.0            # via pytest
-py==1.8.0                 # via pytest
-pyparsing==2.4.2          # via packaging
-pytest-cov==2.7.1
-pytest-django==3.5.1
+packaging==20.1           # via pytest
+pluggy==0.13.1            # via pytest
+py==1.8.1                 # via pytest
+pyparsing==2.4.6          # via packaging
+pytest-cov==2.8.1
+pytest-django==3.8.0
 pytest==4.6.5
-pytz==2019.2              # via django
-six==1.12.0               # via model-mommy, more-itertools, packaging, pytest
+pytz==2019.3              # via django
+six==1.14.0               # via more-itertools, packaging, pytest
 sqlparse==0.3.0           # via django
-wcwidth==0.1.7            # via pytest
-zipp==0.6.0               # via importlib-metadata
+wcwidth==0.1.8            # via pytest
+zipp==2.1.0               # via importlib-metadata

--- a/requirements/travis.in
+++ b/requirements/travis.in
@@ -1,6 +1,5 @@
 # Requirements for running tests in Travis
 
 codecov                   # Code coverage reporting
-more-itertools==5.0.0     # pinned to support python 2.7
 tox                       # Virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,24 +4,23 @@
 #
 #    pip-compile --output-file=requirements/travis.txt requirements/travis.in
 #
-attrs==19.1.0             # via packaging
-certifi==2019.6.16        # via requests
+certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.15
-coverage==4.5.4           # via codecov
+coverage==5.0.3           # via codecov
 filelock==3.0.12          # via tox
 idna==2.8                 # via requests
-importlib-metadata==0.19  # via pluggy, tox
+importlib-metadata==1.5.0  # via pluggy, tox
 more-itertools==5.0.0
-packaging==19.1           # via tox
-pluggy==0.12.0            # via tox
-py==1.8.0                 # via tox
-pyparsing==2.4.2          # via packaging
+packaging==20.1           # via tox
+pluggy==0.13.1            # via tox
+py==1.8.1                 # via tox
+pyparsing==2.4.6          # via packaging
 requests==2.22.0          # via codecov
-six==1.12.0               # via more-itertools, packaging, tox
+six==1.14.0               # via more-itertools, packaging, tox
 toml==0.10.0              # via tox
-tox-battery==0.5.1
-tox==3.13.2
-urllib3==1.25.3           # via requests
-virtualenv==16.7.4        # via tox
-zipp==0.6.0               # via importlib-metadata
+tox-battery==0.5.2
+tox==3.14.3
+urllib3==1.25.8           # via requests
+virtualenv==16.7.9        # via tox
+zipp==2.1.0               # via importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -11,13 +11,12 @@ coverage==5.0.3           # via codecov
 filelock==3.0.12          # via tox
 idna==2.8                 # via requests
 importlib-metadata==1.5.0  # via pluggy, tox
-more-itertools==5.0.0
 packaging==20.1           # via tox
 pluggy==0.13.1            # via tox
 py==1.8.1                 # via tox
 pyparsing==2.4.6          # via packaging
 requests==2.22.0          # via codecov
-six==1.14.0               # via more-itertools, packaging, tox
+six==1.14.0               # via packaging, tox
 toml==0.10.0              # via tox
 tox-battery==0.5.2
 tox==3.14.3

--- a/setup.py
+++ b/setup.py
@@ -47,25 +47,22 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        "Django>=1.8,<2.3"
+        "Django>=1.11,<3.1"
     ],
     license="MIT",
     zip_safe=False,
     keywords='Django REST Framework, Serializers, REST, API, Django',
     classifiers=[
-        'Development Status :: 3 - Alpha',
         'Framework :: Django',
-        'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py36}-django{110,111},py36-django20,py36-django21,py36-django22
+envlist = py37-django{111,21,22,30}
 
 [pytest]
 DJANGO_SETTINGS_MODULE = test_settings
@@ -10,11 +10,11 @@ python_classes=*Tests
 
 [testenv]
 deps =
-    django10: Django>=1.10,<1.11
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
+    django30: Django>=3.0,<3.1
     -r{toxinidir}/requirements/test.txt
 commands =
     py.test {posargs}


### PR DESCRIPTION
**Description:** 
Drop support to old versions

Upgrades tox and requirements to only support deps versions that are still supported by their maintainers

* Support Python 3.7
* Support Django 3.0
* Drop support to Django 1.10
* Drop support to Python 2.7
* Drop support to Python 3.6

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
