### PR TITLE
Removes Django version pin for 3.x and add restriction only for Django 4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        "Django>=1.11,<=3.1"
+        "Django>=1.11,<4"
     ],
     license="MIT",
     zip_safe=False,


### PR DESCRIPTION
**Description:** Removes Django version pin for 3.x and add restriction only for Django 4. This will help with not having to update the package on every small update on Django.

**Dependencies:** closes #32. 

**Merge deadline:** List merge deadline (if any)

**Reviewers:**
- [ ] @filipeximenes  

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
