### PR TITLE
fix(setup): correct pypi license classifier to MIT

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
+        'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
**Description:** related to [this issue](https://github.com/vintasoftware/drf-rw-serializers/issues/47), the license was set on PyPI classifiers is not consistent with project's and metadata's MIT license, I this PR PyPI classifier is corrected.

**Reviewers:**
- [@hugobessa] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped - I think not needed.
- [ ] Changelog record added - I think not needed.
- [ ] Documentation updated (not only docstrings) - already correct, I think not needed.
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
