### PR TITLE
Support Django 5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        "Django>=1.11,<5"
+        "Django>=1.11,<5.1"
     ],
     license="MIT",
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        "Django>=1.11,<5.1"
+        "Django>=1.11,<6"
     ],
     license="MIT",
     zip_safe=False,


### PR DESCRIPTION
**Description:** Describe in a couple of sentence what this PR adds

The installable Django version written in setup.py did not support 5.0.x.  
The description of the Django versions that can be installed has been corrected so that Django 5.0.x can be installed.

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

None

**Merge deadline:** List merge deadline (if any)

ASAP

**Installation instructions:** List any non-trivial installation instructions.

At first, install Django which version range is `>=4.0,<5.1`.

```command
$ pip install "Django>=4.0,<5.1"
Collecting Django<5.1,>=4.0
  Downloading Django-5.0.1-py3-none-any.whl.metadata (4.2 kB)
Collecting asgiref<4,>=3.7.0 (from Django<5.1,>=4.0)
  Downloading asgiref-3.7.2-py3-none-any.whl.metadata (9.2 kB)
Collecting sqlparse>=0.3.1 (from Django<5.1,>=4.0)
  Downloading sqlparse-0.4.4-py3-none-any.whl (41 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 41.2/41.2 kB 8.4 MB/s eta 0:00:00
Downloading Django-5.0.1-py3-none-any.whl (8.1 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 8.1/8.1 MB 72.0 MB/s eta 0:00:00
Downloading asgiref-3.7.2-py3-none-any.whl (24 kB)
Installing collected packages: sqlparse, asgiref, Django
Successfully installed Django-5.0.1 asgiref-3.7.2 sqlparse-0.4.4
```

Success installed Django `5.0.1`.  
Then install `drf-rw-serializers` latest version.

```command
$ pip install drf-rw-serializers
Collecting drf-rw-serializers
  Downloading drf_rw_serializers-1.1.0-py2.py3-none-any.whl.metadata (6.2 kB)
Collecting Django<5,>=1.11 (from drf-rw-serializers)
  Downloading Django-4.2.9-py3-none-any.whl.metadata (4.2 kB)
Requirement already satisfied: asgiref<4,>=3.6.0 in /usr/local/lib/python3.11/site-packages (from Django<5,>=1.11->drf-rw-serializers) (3.7.2)
Requirement already satisfied: sqlparse>=0.3.1 in /usr/local/lib/python3.11/site-packages (from Django<5,>=1.11->drf-rw-serializers) (0.4.4)
Downloading drf_rw_serializers-1.1.0-py2.py3-none-any.whl (7.3 kB)
Downloading Django-4.2.9-py3-none-any.whl (8.0 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 8.0/8.0 MB 73.2 MB/s eta 0:00:00
Installing collected packages: Django, drf-rw-serializers
  Attempting uninstall: Django
    Found existing installation: Django 5.0.1
    Uninstalling Django-5.0.1:
      Successfully uninstalled Django-5.0.1
Successfully installed Django-4.2.9 drf-rw-serializers-1.1.0
```

Success installed it. However, downgraded Django version to `4.2.9`.

**Testing instructions:**

We need Python3.10 or later where want to installing Django 5.0.x.

1. Clone my repository which branch is `support-django-5.0` and change directory.
2. Run `pip install .`
3. Make sure your Django version is `5.0.x`.

<details>
<summary>Executed result</summary>

```command
$ git clone --depth 1 -b support-django-5.0 https://github.com/nnsnodnb/drf-rw-serializers.git && cd drf-rw-serializers
...
$ pip install .
Processing /drf-rw-serializers
  Preparing metadata (setup.py) ... done
Collecting Django<5.1,>=1.11 (from drf-rw-serializers==1.1.0)
  Downloading Django-5.0.1-py3-none-any.whl (8.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 8.1/8.1 MB 73.6 MB/s eta 0:00:00
Collecting asgiref<4,>=3.7.0 (from Django<5.1,>=1.11->drf-rw-serializers==1.1.0)
  Downloading asgiref-3.7.2-py3-none-any.whl (24 kB)
Collecting sqlparse>=0.3.1 (from Django<5.1,>=1.11->drf-rw-serializers==1.1.0)
  Downloading sqlparse-0.4.4-py3-none-any.whl (41 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 41.2/41.2 kB 20.3 MB/s eta 0:00:00
Building wheels for collected packages: drf-rw-serializers
  Building wheel for drf-rw-serializers (setup.py) ... done
  Created wheel for drf-rw-serializers: filename=drf_rw_serializers-1.1.0-py2.py3-none-any.whl size=7273 sha256=893cd54cd3498f3f67373abeee2dee211e5538a2baea9a9a29aa2a6ea665f95b
  Stored in directory: /root/.cache/pip/wheels/6e/75/b8/8661ceb685ea76e06266a9c4d5913a395ceeb0c334f667b5a0
Successfully built drf-rw-serializers
Installing collected packages: sqlparse, asgiref, Django, drf-rw-serializers
Successfully installed Django-5.0.1 asgiref-3.7.2 drf-rw-serializers-1.1.0 sqlparse-0.4.4
```

</details>

**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
