### PR TITLE
Add project urls for PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,13 @@ authors = ["Vinta Software <contact@vinta.com.br>"]
 license = "MIT"
 readme = "README.rst"
 
+[tool.poetry.urls]
+"Homepage" = "https://github.com/vintasoftware/drf-rw-serializers"
+"Documentation" = "https://drf-rw-serializers.readthedocs.io"
+"Bug Tracker" = "https://github.com/vintasoftware/drf-rw-serializers/issues"
+"Source" = "https://github.com/vintasoftware/drf-rw-serializers/"
+"Changelog" = "https://github.com/vintasoftware/drf-rw-serializers/blob/main/CHANGELOG.rst"
+
 [tool.poetry.dependencies]
 python = "^3.8"
 djangorestframework = "^3.15.1"


### PR DESCRIPTION
## Motivation and Context

PyPI does not show relevant project URLs (in the Project links section) because they have not been configured on the package build tools.

For example, django displays Project links section like this in PyPI:

![image](https://github.com/vintasoftware/drf-rw-serializers/assets/807599/15398b47-0571-4ec3-bb4c-33838acef502)


## <a name="description" href="#description">Description</a>

This pull request includes configuring the relevant project URLs to be shown in PyPI

Relevant docs: 

https://python-poetry.org/docs/pyproject#urls
https://github.com/pypa/sampleproject/blob/main/pyproject.toml#L138-L153
