### PR TITLE
Refactor strategy to handle `RecursionError` between `get_serializer_class`, `get_read_serializer`, and `get_write_serializer`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[1.4.0] - 2024-06-05
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Fixed
+_____
+* Fix a regression in the `get_read_serializer_class` and `get_write_serializer_class`
+methods to return `get_serializer_class` as default.
+
 [1.3.0] - 2024-06-03
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Fixed

--- a/docs/cross_library_integrations.rst
+++ b/docs/cross_library_integrations.rst
@@ -1,0 +1,10 @@
+==========================
+Cross-Library Integrations
+==========================
+
+drf-spectacular
+---------------
+
+If your project is using both `drf-rw-serializers` and `drf-spectacular`, there
+are specific configurations to be made. Detailed steps for this integration are
+provided in the `drf-spectacular documentation <https://drf-spectacular.readthedocs.io/en/latest/blueprints.html#drf-rw-serializers>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ Contents:
    readme
    installation
    usage
+   cross_library_integrations
    contributing
    authors
    changelog

--- a/drf_rw_serializers/__init__.py
+++ b/drf_rw_serializers/__init__.py
@@ -5,7 +5,7 @@ separated serializers for read and write operations.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 
 # pylint: disable=invalid-name
 default_app_config = "drf_rw_serializers.apps.DrfRwSerializersConfig"

--- a/drf_rw_serializers/generics.py
+++ b/drf_rw_serializers/generics.py
@@ -36,8 +36,8 @@ class GenericAPIView(generics.GenericAPIView):
                     "attribute, or override the `get_read_serializer_class()` or "
                     "`get_serializer_class()` method." % self.__class__.__name__
                 )
-                # `use_serializer_class` is used to prevent a `RecursionError`
-                return self.get_read_serializer_class(use_serializer_class=True)
+                # `default_to_serializer_class` is used to prevent a `RecursionError`
+                return self.get_read_serializer_class(default_to_serializer_class=True)
 
             if self.request.method in ["POST", "PUT", "PATCH", "DELETE"]:
                 assert (
@@ -48,8 +48,8 @@ class GenericAPIView(generics.GenericAPIView):
                     "attribute, or override the `get_write_serializer_class()` or "
                     "`get_serializer_class()` method." % self.__class__.__name__
                 )
-                # `use_serializer_class` is used to prevent a `RecursionError`
-                return self.get_write_serializer_class(use_serializer_class=True)
+                # `default_to_serializer_class` is used to prevent a `RecursionError`
+                return self.get_write_serializer_class(default_to_serializer_class=True)
 
         assert (
             self.serializer_class is not None
@@ -70,7 +70,7 @@ class GenericAPIView(generics.GenericAPIView):
         kwargs["context"] = self.get_serializer_context()
         return serializer_class(*args, **kwargs)
 
-    def get_read_serializer_class(self, use_serializer_class: bool = False):
+    def get_read_serializer_class(self, default_to_serializer_class: bool = False):
         """
         Return the class to use for the serializer.
         Defaults to using `self.read_serializer_class`.
@@ -81,7 +81,7 @@ class GenericAPIView(generics.GenericAPIView):
         (Eg. admins get full serialization, others get basic serialization)
         """
         if getattr(self, "read_serializer_class", None) is None:
-            if use_serializer_class:
+            if default_to_serializer_class:
                 return self.serializer_class
 
             return self.get_serializer_class()
@@ -97,7 +97,7 @@ class GenericAPIView(generics.GenericAPIView):
         kwargs["context"] = self.get_serializer_context()
         return serializer_class(*args, **kwargs)
 
-    def get_write_serializer_class(self, use_serializer_class: bool = False):
+    def get_write_serializer_class(self, default_to_serializer_class: bool = False):
         """
         Return the class to use for the serializer.
         Defaults to using `self.write_serializer_class`.
@@ -108,7 +108,7 @@ class GenericAPIView(generics.GenericAPIView):
         (Eg. admins can send extra fields, others cannot)
         """
         if getattr(self, "write_serializer_class", None) is None:
-            if use_serializer_class:
+            if default_to_serializer_class:
                 return self.serializer_class
 
             return self.get_serializer_class()

--- a/drf_rw_serializers/generics.py
+++ b/drf_rw_serializers/generics.py
@@ -11,35 +11,19 @@ from .mixins import (
 
 
 class GenericAPIView(generics.GenericAPIView):
-    def _get_serializer_class(self):
-        """
-        Return the class to use for the serializer.
-        Defaults to using `self.serializer_class`.
-        You may want to override this if you need to provide different
-        serializations depending on the incoming request.
-        (Eg. admins get full serialization, others get basic serialization)
-        """
-        assert (
-            self.serializer_class is not None
-            or getattr(self, "read_serializer_class", None) is not None
-        ), (
-            "'%s' should either include one of `serializer_class` and `read_serializer_class` "
-            "attribute, or override one of the `get_serializer_class()`, "
-            "`get_read_serializer_class()` method." % self.__class__.__name__
-        )
-
-        return self.serializer_class
-
     def get_serializer_class(self):
         """
         Return the class to use for the serializer.
         Defaults to using `self.serializer_class`.
+
         If the request method is GET, it tries to use `self.read_serializer_class`.
         If the request method is not GET, it tries to use `self.write_serializer_class`.
         If the specific serializer class for the request method is not set, it falls back to
         `self.serializer_class`.
+
         You may want to override this if you need to provide different
         serializations depending on the incoming request.
+
         (Eg. admins get full serialization, others get basic serialization)
         """
         if hasattr(self, "request"):
@@ -52,7 +36,8 @@ class GenericAPIView(generics.GenericAPIView):
                     "attribute, or override the `get_read_serializer_class()` or "
                     "`get_serializer_class()` method." % self.__class__.__name__
                 )
-                return self.get_read_serializer_class()
+                # `use_serializer_class` is used to prevent a `RecursionError`
+                return self.get_read_serializer_class(use_serializer_class=True)
 
             if self.request.method in ["POST", "PUT", "PATCH", "DELETE"]:
                 assert (
@@ -63,9 +48,19 @@ class GenericAPIView(generics.GenericAPIView):
                     "attribute, or override the `get_write_serializer_class()` or "
                     "`get_serializer_class()` method." % self.__class__.__name__
                 )
-                return self.get_write_serializer_class()
+                # `use_serializer_class` is used to prevent a `RecursionError`
+                return self.get_write_serializer_class(use_serializer_class=True)
 
-        return self._get_serializer_class()
+        assert (
+            self.serializer_class is not None
+            or getattr(self, "read_serializer_class", None) is not None
+        ), (
+            "'%s' should either include one of `serializer_class` and `read_serializer_class` "
+            "attribute, or override one of the `get_serializer_class()`, "
+            "`get_read_serializer_class()` method." % self.__class__.__name__
+        )
+
+        return self.serializer_class
 
     def get_read_serializer(self, *args, **kwargs):
         """
@@ -75,16 +70,21 @@ class GenericAPIView(generics.GenericAPIView):
         kwargs["context"] = self.get_serializer_context()
         return serializer_class(*args, **kwargs)
 
-    def get_read_serializer_class(self):
+    def get_read_serializer_class(self, use_serializer_class: bool = False):
         """
         Return the class to use for the serializer.
         Defaults to using `self.read_serializer_class`.
+
         You may want to override this if you need to provide different
         serializations depending on the incoming request.
+
         (Eg. admins get full serialization, others get basic serialization)
         """
         if getattr(self, "read_serializer_class", None) is None:
-            return self._get_serializer_class()
+            if use_serializer_class:
+                return self.serializer_class
+
+            return self.get_serializer_class()
 
         return self.read_serializer_class
 
@@ -97,16 +97,21 @@ class GenericAPIView(generics.GenericAPIView):
         kwargs["context"] = self.get_serializer_context()
         return serializer_class(*args, **kwargs)
 
-    def get_write_serializer_class(self):
+    def get_write_serializer_class(self, use_serializer_class: bool = False):
         """
         Return the class to use for the serializer.
         Defaults to using `self.write_serializer_class`.
+
         You may want to override this if you need to provide different
         serializations depending on the incoming request.
+
         (Eg. admins can send extra fields, others cannot)
         """
         if getattr(self, "write_serializer_class", None) is None:
-            return self._get_serializer_class()
+            if use_serializer_class:
+                return self.serializer_class
+
+            return self.get_serializer_class()
 
         return self.write_serializer_class
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "drf-rw-serializers"
-version = "1.3.0"
+version = "1.4.0"
 description = "Generic views, viewsets and mixins that extend the Django REST Framework ones adding separated serializers for read and write operations"
 authors = ["Vinta Software <contact@vinta.com.br>"]
 license = "MIT"

--- a/test_settings.py
+++ b/test_settings.py
@@ -38,3 +38,5 @@ LOCALE_PATHS = [
 ROOT_URLCONF = "example_app.urls"
 
 SECRET_KEY = "insecure-secret-key"
+
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -61,6 +61,21 @@ class GenericAPIViewGetSerializerClassTests(BaseTestCase):
             ),
         )
 
+    def test_get_serializer_class_override_provided(self):
+        class GetSerializerClassView(generics.GenericAPIView):
+            def get_serializer_class(self):
+                return OrderedMealDetailsSerializer
+
+        self.assertEqual(
+            GetSerializerClassView().get_serializer_class(), OrderedMealDetailsSerializer
+        )
+        self.assertEqual(
+            GetSerializerClassView().get_read_serializer_class(), OrderedMealDetailsSerializer
+        )
+        self.assertEqual(
+            GetSerializerClassView().get_write_serializer_class(), OrderedMealDetailsSerializer
+        )
+
     def test_no_request_provided(self):
         # Return serializer_class over read_serializer_class and write_serializer_class
         self.assertEqual(
@@ -108,6 +123,25 @@ class GenericAPIViewGetSerializerClassTests(BaseTestCase):
             self.FullSerializerView().get_serializer_class(), OrderedMealDetailsSerializer
         )
 
+    def test_all_get_serializer_class_override_provided(self):
+        class GetSerializerClassView(generics.GenericAPIView):
+            def get_serializer_class(self):
+                return OrderedMealDetailsSerializer
+
+            def get_read_serializer_class(self, use_serializer_class: bool = False):
+                return OrderListSerializer
+
+            def get_write_serializer_class(self, use_serializer_class: bool = False):
+                return OrderCreateSerializer
+
+        self.assertEqual(
+            GetSerializerClassView().get_serializer_class(), OrderedMealDetailsSerializer
+        )
+        self.assertEqual(GetSerializerClassView().get_read_serializer_class(), OrderListSerializer)
+        self.assertEqual(
+            GetSerializerClassView().get_write_serializer_class(), OrderCreateSerializer
+        )
+
 
 class GenericAPIViewGetReadSerializerClassTests(BaseTestCase):
     def test_read_serializer_class_not_provided(self):
@@ -115,11 +149,11 @@ class GenericAPIViewGetReadSerializerClassTests(BaseTestCase):
             pass
 
         with mock.patch.object(
-            NoReadSerializerView, "_get_serializer_class"
-        ) as mock__get_serializer_class:
+            NoReadSerializerView, "get_serializer_class"
+        ) as mock_get_serializer_class:
             NoReadSerializerView().get_read_serializer_class()
 
-        mock__get_serializer_class.assert_called_once()
+        mock_get_serializer_class.assert_called_once()
 
     def test_read_serializer_class_provided(self):
         class ReadSerializerClassProvided(generics.GenericAPIView):
@@ -130,6 +164,31 @@ class GenericAPIViewGetReadSerializerClassTests(BaseTestCase):
             OrderListSerializer,
         )
 
+    def test_use_serializer_class_fallback(self):
+        class SerializerClassView(generics.GenericAPIView):
+            serializer_class = OrderedMealDetailsSerializer
+
+        self.assertEqual(
+            SerializerClassView().get_read_serializer_class(use_serializer_class=True),
+            OrderedMealDetailsSerializer,
+        )
+
+        with mock.patch.object(
+            SerializerClassView, "get_serializer_class"
+        ) as mock_get_serializer_class:
+            SerializerClassView().get_read_serializer_class(use_serializer_class=False)
+
+        mock_get_serializer_class.assert_called_once()
+
+    def test_get_read_serializer_class_override_provided(self):
+        class GetReadSerializerClassView(generics.GenericAPIView):
+            def get_read_serializer_class(self, use_serializer_class: bool = False):
+                return OrderListSerializer
+
+        self.assertEqual(
+            GetReadSerializerClassView().get_read_serializer_class(), OrderListSerializer
+        )
+
 
 class GenericAPIViewGetWriteSerializerClassTests(BaseTestCase):
     def test_write_serializer_class_not_provided(self):
@@ -137,11 +196,11 @@ class GenericAPIViewGetWriteSerializerClassTests(BaseTestCase):
             pass
 
         with mock.patch.object(
-            NoWriteSerializerView, "_get_serializer_class"
-        ) as mock__get_serializer_class:
+            NoWriteSerializerView, "get_serializer_class"
+        ) as mock_get_serializer_class:
             NoWriteSerializerView().get_write_serializer_class()
 
-        mock__get_serializer_class.assert_called_once()
+        mock_get_serializer_class.assert_called_once()
 
     def test_write_serializer_class_provided(self):
         class WriteSerializerClassProvided(generics.GenericAPIView):
@@ -150,6 +209,31 @@ class GenericAPIViewGetWriteSerializerClassTests(BaseTestCase):
         self.assertEqual(
             WriteSerializerClassProvided().get_write_serializer_class(),
             OrderCreateSerializer,
+        )
+
+    def test_use_serializer_class_fallback(self):
+        class SerializerClassView(generics.GenericAPIView):
+            serializer_class = OrderedMealDetailsSerializer
+
+        self.assertEqual(
+            SerializerClassView().get_write_serializer_class(use_serializer_class=True),
+            OrderedMealDetailsSerializer,
+        )
+
+        with mock.patch.object(
+            SerializerClassView, "get_serializer_class"
+        ) as mock_get_serializer_class:
+            SerializerClassView().get_write_serializer_class(use_serializer_class=False)
+
+        mock_get_serializer_class.assert_called_once()
+
+    def test_get_write_serializer_class_override_provided(self):
+        class GetWriteSerializerClassView(generics.GenericAPIView):
+            def get_write_serializer_class(self, use_serializer_class: bool = False):
+                return OrderCreateSerializer
+
+        self.assertEqual(
+            GetWriteSerializerClassView().get_write_serializer_class(), OrderCreateSerializer
         )
 
 

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -128,10 +128,10 @@ class GenericAPIViewGetSerializerClassTests(BaseTestCase):
             def get_serializer_class(self):
                 return OrderedMealDetailsSerializer
 
-            def get_read_serializer_class(self, use_serializer_class: bool = False):
+            def get_read_serializer_class(self, default_to_serializer_class: bool = False):
                 return OrderListSerializer
 
-            def get_write_serializer_class(self, use_serializer_class: bool = False):
+            def get_write_serializer_class(self, default_to_serializer_class: bool = False):
                 return OrderCreateSerializer
 
         self.assertEqual(
@@ -169,20 +169,20 @@ class GenericAPIViewGetReadSerializerClassTests(BaseTestCase):
             serializer_class = OrderedMealDetailsSerializer
 
         self.assertEqual(
-            SerializerClassView().get_read_serializer_class(use_serializer_class=True),
+            SerializerClassView().get_read_serializer_class(default_to_serializer_class=True),
             OrderedMealDetailsSerializer,
         )
 
         with mock.patch.object(
             SerializerClassView, "get_serializer_class"
         ) as mock_get_serializer_class:
-            SerializerClassView().get_read_serializer_class(use_serializer_class=False)
+            SerializerClassView().get_read_serializer_class(default_to_serializer_class=False)
 
         mock_get_serializer_class.assert_called_once()
 
     def test_get_read_serializer_class_override_provided(self):
         class GetReadSerializerClassView(generics.GenericAPIView):
-            def get_read_serializer_class(self, use_serializer_class: bool = False):
+            def get_read_serializer_class(self, default_to_serializer_class: bool = False):
                 return OrderListSerializer
 
         self.assertEqual(
@@ -216,20 +216,20 @@ class GenericAPIViewGetWriteSerializerClassTests(BaseTestCase):
             serializer_class = OrderedMealDetailsSerializer
 
         self.assertEqual(
-            SerializerClassView().get_write_serializer_class(use_serializer_class=True),
+            SerializerClassView().get_write_serializer_class(default_to_serializer_class=True),
             OrderedMealDetailsSerializer,
         )
 
         with mock.patch.object(
             SerializerClassView, "get_serializer_class"
         ) as mock_get_serializer_class:
-            SerializerClassView().get_write_serializer_class(use_serializer_class=False)
+            SerializerClassView().get_write_serializer_class(default_to_serializer_class=False)
 
         mock_get_serializer_class.assert_called_once()
 
     def test_get_write_serializer_class_override_provided(self):
         class GetWriteSerializerClassView(generics.GenericAPIView):
-            def get_write_serializer_class(self, use_serializer_class: bool = False):
+            def get_write_serializer_class(self, default_to_serializer_class: bool = False):
                 return OrderCreateSerializer
 
         self.assertEqual(


### PR DESCRIPTION
**Description:** Describe in a couple of sentence what this PR adds

Refactor strategy to handle `RecursionError` between `get_serializer_class`, `get_read_serializer`, and `get_write_serializer`

Relates to PR #77

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

Resolves #86 

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

[Screencast from 05-06-2024 15:49:26.webm](https://github.com/vintasoftware/drf-rw-serializers/assets/22326737/3a9f768c-1e02-4aab-a787-df93f176218b)

[Screencast from 05-06-2024 15:52:11.webm](https://github.com/vintasoftware/drf-rw-serializers/assets/22326737/bc4d6058-2f88-4840-b680-971c4db9269d)


**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
